### PR TITLE
Remove redundant mad_mimi_configuration.rb file under lib.

### DIFF
--- a/lib/spree/mad_mimi_configuration.rb
+++ b/lib/spree/mad_mimi_configuration.rb
@@ -1,6 +1,0 @@
-module Spree
-  class MadMimiConfiguration < Preferences::Configuration
-    preference :access_token,  :string
-    preference :refresh_token, :string
-  end
-end


### PR DESCRIPTION
The configuration file used by the app is under models.
